### PR TITLE
[wip] implement cargo run node info cli cmd

### DIFF
--- a/crates/cli/src/commands/node/info.rs
+++ b/crates/cli/src/commands/node/info.rs
@@ -1,1 +1,21 @@
+use std::path::PathBuf;
 
+use primitives::DEFAULT_VRRB_DB_PATH;
+
+use crate::{
+    commands::utils::read_node_config_from_file,
+    result::{CliError, Result},
+};
+
+pub async fn exec() -> Result<()> {
+    let node_config_path = format!("{}{}", DEFAULT_VRRB_DB_PATH, "/config.json");
+    let node_config = read_node_config_from_file(PathBuf::from(node_config_path))
+        .map_err(|err| CliError::Other(format!("unable to read node config: {err}")))?;
+
+    let node_config = serde_json::to_string_pretty(&node_config)
+        .map_err(|err| CliError::Other(format!("unable to serialize node config: {err}")))?;
+
+    println!("{}", node_config);
+
+    Ok(())
+}

--- a/crates/cli/src/commands/node/mod.rs
+++ b/crates/cli/src/commands/node/mod.rs
@@ -30,7 +30,7 @@ pub async fn exec(args: NodeOpts) -> Result<()> {
 
     match sub_cmd {
         NodeCmd::Run(opts) => run(opts).await,
-        NodeCmd::Info => Ok(()),
+        NodeCmd::Info => info::exec().await,
         _ => Err(CliError::InvalidCommand(format!("{:?}", sub_cmd))),
     }
 }

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -19,7 +19,10 @@ use vrrb_core::{
     keypair::{self, read_keypair_file, write_keypair_file, Keypair},
 };
 
-use crate::result::{CliError, Result};
+use crate::{
+    commands::utils::write_node_config_from_file,
+    result::{CliError, Result},
+};
 
 const DEFAULT_OS_ASSIGNED_PORT_ADDRESS: &str = "127.0.0.1:0";
 const DEFAULT_JSONRPC_ADDRESS: &str = "127.0.0.1:9293";
@@ -263,6 +266,9 @@ pub async fn run(args: RunOpts) -> Result<()> {
     if args.debug_config {
         dbg!(&node_config);
     }
+
+    write_node_config_from_file(&node_config)
+        .map_err(|err| CliError::Other(format!("unable to write node config: {err}")))?;
 
     if args.dettached {
         run_dettached(node_config).await

--- a/crates/cli/src/commands/utils.rs
+++ b/crates/cli/src/commands/utils.rs
@@ -7,17 +7,6 @@ use crate::{
     result::{CliError, Result},
 };
 
-// pub fn read_node_config_from_file(config_file_path: PathBuf) ->
-// crate::result::Result<RunOpts> {     let path_str =
-// config_file_path.to_str().unwrap_or_default();
-
-//     let node_config = RunOpts::from_file(path_str)
-//         .map_err(|err| CliError::Other(format!("failed to read config file:
-// {err}")))?;
-
-//     Ok(node_config)
-// }
-
 pub fn write_node_config_from_file(node_config: &NodeConfig) -> Result<()> {
     let node_config_dir = node_config.db_path();
     let node_config_path = node_config_dir.join("config.json");

--- a/crates/cli/src/commands/utils.rs
+++ b/crates/cli/src/commands/utils.rs
@@ -1,11 +1,40 @@
 use std::path::PathBuf;
 
-use crate::{commands::node::RunOpts, result::CliError};
+use vrrb_config::NodeConfig;
 
-pub fn read_node_config_from_file(config_file_path: PathBuf) -> crate::result::Result<RunOpts> {
+use crate::{
+    commands::node::RunOpts,
+    result::{CliError, Result},
+};
+
+// pub fn read_node_config_from_file(config_file_path: PathBuf) ->
+// crate::result::Result<RunOpts> {     let path_str =
+// config_file_path.to_str().unwrap_or_default();
+
+//     let node_config = RunOpts::from_file(path_str)
+//         .map_err(|err| CliError::Other(format!("failed to read config file:
+// {err}")))?;
+
+//     Ok(node_config)
+// }
+
+pub fn write_node_config_from_file(node_config: &NodeConfig) -> Result<()> {
+    let node_config_dir = node_config.db_path();
+    let node_config_path = node_config_dir.join("config.json");
+
+    let node_config_json = serde_json::to_string_pretty(&node_config)
+        .map_err(|err| CliError::Other(format!("unable to serialize node config: {err}")))?;
+
+    std::fs::write(node_config_path, node_config_json)
+        .map_err(|err| CliError::Other(format!("unable to write node config file: {err}")))?;
+
+    Ok(())
+}
+
+pub fn read_node_config_from_file(config_file_path: PathBuf) -> Result<NodeConfig> {
     let path_str = config_file_path.to_str().unwrap_or_default();
 
-    let node_config = RunOpts::from_file(path_str)
+    let node_config = NodeConfig::from_file(path_str)
         .map_err(|err| CliError::Other(format!("failed to read config file: {err}")))?;
 
     Ok(node_config)

--- a/crates/vrrb_config/Cargo.toml
+++ b/crates/vrrb_config/Cargo.toml
@@ -14,3 +14,4 @@ vrrb_core = { workspace = true }
 secp256k1 = { workspace = true }
 serde = { workspace = true }
 uuid = { workspace = true }
+config = { workspace = true }

--- a/crates/vrrb_config/src/lib.rs
+++ b/crates/vrrb_config/src/lib.rs
@@ -1,5 +1,5 @@
 mod bootstrap;
-mod node_config;
+pub mod node_config;
 
 pub use node_config::*;
 

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -115,19 +115,6 @@ impl NodeConfig {
 
     pub fn from_file(config_path: &str) -> std::result::Result<Self, ConfigError> {
         let s = Config::builder()
-            // .set_default("id", Uuid::new_v4().to_string())?
-            // .set_default("data_dir", DEFAULT_VRRB_DATA_DIR_PATH)?
-            // .set_default("db_path", DEFAULT_VRRB_DB_PATH)?
-            // .set_default("node_type", "full")?
-            // .set_default("jsonrpc_api_address", DEFAULT_JSONRPC_ADDRESS)?
-            // .set_default("http_api_address", DEFAULT_OS_ASSIGNED_PORT_ADDRESS)?
-            // .set_default("http_api_title", "Node API")?
-            // .set_default("http_api_version", "1.0.1")?
-            // .set_default("bootstrap_node_addresses", default_bootstrap_addresses)?
-            // .set_default("preload_mock_state", false)?
-            // .set_default("debug_config", false)?
-            // .set_default("bootstrap", false)?
-            // .set_default("dettached", false)?
             .add_source(File::with_name(config_path))
             .build()?;
 

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -4,15 +4,16 @@ use std::{
     time::Duration,
 };
 
+use config::{Config, ConfigError, File};
 use derive_builder::Builder;
 use primitives::{NodeId, NodeIdx, NodeType, DEFAULT_VRRB_DATA_DIR_PATH};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use vrrb_core::keypair::Keypair;
 
 use crate::bootstrap::BootstrapConfig;
 
-#[derive(Builder, Debug, Clone, Deserialize)]
+#[derive(Builder, Debug, Clone, Deserialize, Serialize)]
 pub struct NodeConfig {
     /// UUID that identifies each node
     pub id: NodeId,
@@ -63,8 +64,10 @@ pub struct NodeConfig {
     pub preload_mock_state: bool,
 
     /// Bootstrap configuration
+    #[serde(skip_serializing)]
     pub bootstrap_config: Option<BootstrapConfig>,
 
+    #[serde(skip_serializing)]
     pub keypair: Keypair,
 
     #[builder(default = "false")]
@@ -108,6 +111,27 @@ impl NodeConfig {
             keypair: self.keypair.clone(),
             ..other
         }
+    }
+
+    pub fn from_file(config_path: &str) -> std::result::Result<Self, ConfigError> {
+        let s = Config::builder()
+            // .set_default("id", Uuid::new_v4().to_string())?
+            // .set_default("data_dir", DEFAULT_VRRB_DATA_DIR_PATH)?
+            // .set_default("db_path", DEFAULT_VRRB_DB_PATH)?
+            // .set_default("node_type", "full")?
+            // .set_default("jsonrpc_api_address", DEFAULT_JSONRPC_ADDRESS)?
+            // .set_default("http_api_address", DEFAULT_OS_ASSIGNED_PORT_ADDRESS)?
+            // .set_default("http_api_title", "Node API")?
+            // .set_default("http_api_version", "1.0.1")?
+            // .set_default("bootstrap_node_addresses", default_bootstrap_addresses)?
+            // .set_default("preload_mock_state", false)?
+            // .set_default("debug_config", false)?
+            // .set_default("bootstrap", false)?
+            // .set_default("dettached", false)?
+            .add_source(File::with_name(config_path))
+            .build()?;
+
+        Ok(s.try_deserialize().unwrap_or_default())
     }
 }
 


### PR DESCRIPTION
## Clarifications

- Where do we want to store the config? _Currently `.vrrb/node/db/config.json`_
- Do we want to omit the concept of RunOpts for now (config flag overriding)? 
- Do want to actually serialize these values?
  - https://github.com/pineappleworkshop/vrrb/pull/1/files#diff-061ca0526681e08b2c2eb98b03d704b6a3582fd284821fd68096d6e6e2b78eb9R67
  - https://github.com/pineappleworkshop/vrrb/pull/1/files#diff-061ca0526681e08b2c2eb98b03d704b6a3582fd284821fd68096d6e6e2b78eb9R70
- The CLI currently is an on machine style implementation meaning, the CMD needs to be run on an active node, is this intended?

---

## Info

```bash
# To run info CMD, we need to first run the node to write the initial config.json with default values
$ cargo run node run
# Run info CMD
$ cargo run node info
{
  "id": "28e72ec5-8e7d-4640-9569-c3da997997f1",
  "idx": 0,
  "data_dir": ".vrrb",
  "db_path": ".vrrb/node/db",
  "raptorq_gossip_address": "127.0.0.1:0",
  "udp_gossip_address": "127.0.0.1:0",
  "node_type": "full",
  "bootstrap_node_addresses": [],
  "http_api_address": "127.0.0.1:0",
  "http_api_title": "VRRB Node",
  "http_api_version": "v.0.1.0",
  "http_api_shutdown_timeout": null,
  "jsonrpc_server_address": "127.0.0.1:0",
  "preload_mock_state": false,
  "disable_networking": false
}
```

---

## Checklist

- [ ] Implement
- [ ] Test
- [ ] Docs
